### PR TITLE
Fixed missions.build_summary if claimedOn has no milliseconds

### DIFF
--- a/src/synack/plugins/missions.py
+++ b/src/synack/plugins/missions.py
@@ -56,8 +56,12 @@ class Missions(Plugin):
         for m in missions:
             if m.get("status") == "CLAIMED":
                 utc = datetime.utcnow()
-                claimed_on = datetime.strptime(m['claimedOn'],
-                                               "%Y-%m-%dT%H:%M:%S.%fZ")
+                try:
+                    claimed_on = datetime.strptime(m['claimedOn'],
+                                                   "%Y-%m-%dT%H:%M:%S.%fZ")
+                except ValueError:
+                    claimed_on = datetime.strptime(m['claimedOn'],
+                                                   "%Y-%m-%dT%H:%M:%SZ")
                 elapsed = int((utc - claimed_on).total_seconds())
                 time = m['maxCompletionTimeInSecs'] - elapsed
                 if time < ret['time'] or ret['time'] == 0:

--- a/test/test_missions.py
+++ b/test/test_missions.py
@@ -124,6 +124,35 @@ class MissionsTestCase(unittest.TestCase):
 
         self.assertEqual(ret, self.missions.build_summary(m))
 
+    def test_build_summary_no_milliseconds(self):
+        """Should be able to handle claimedOn time without milliseconds"""
+        ret = {
+            "count": 2,
+            "value": 75,
+            "time": 79200
+        }
+        now = datetime.datetime.utcnow()
+        t1 = datetime.datetime.strftime(now-datetime.timedelta(hours=2),
+                                        "%Y-%m-%dT%H:%M:%SZ")
+        t2 = datetime.datetime.strftime(now-datetime.timedelta(hours=1),
+                                        "%Y-%m-%dT%H:%M:%SZ")
+        m = [
+            {
+                "status": "CLAIMED",
+                "maxCompletionTimeInSecs": 86400,
+                "payout": {"amount": 50},
+                "claimedOn": t1
+            },
+            {
+                "status": "CLAIMED",
+                "maxCompletionTimeInSecs": 86400,
+                "payout": {"amount": 25},
+                "claimedOn": t2
+            }
+        ]
+
+        self.assertEqual(ret, self.missions.build_summary(m))
+
     def test_get_approved(self):
         """Should request APPROVED missions"""
         self.missions.get = MagicMock()


### PR DESCRIPTION
Sometimes the claimedOn property of a mission is written as `%Y-%m-%dT%H:%M:%SZ` instead of `%Y-%m-%dT%H:%M:%S.%fZ`. An exception used to occur if this happened. This fixes that.