### PR TITLE
Added target analytics

### DIFF
--- a/docs/src/usage/plugins/targets.md
+++ b/docs/src/usage/plugins/targets.md
@@ -299,3 +299,69 @@
 >> >>> h.targets.set_unregistered()
 >> [{"id": "pwjlgmf",...},...]
 >> ```
+
+## targets.get_connections(target, **kwargs)
+
+> Get the connection details of a target
+>
+> | Argments | Type | Description
+> | `target` | db.models.Target | A single Target returned from the database
+> | `kwargs` | kwargs | Information used to look up a Target in the database (ex: `codename`, `slug`, etc.)
+>
+>> Examples
+>> ```python3
+>> >>> h.targets.get_connections(codename='BLINKYBABOON')
+>> {"lifetime_connections":200,"current_connections":0}
+>> ```
+
+## targets.get_submissions_summary(target, hours_ago=None, **kwargs)
+
+> Get a summary of the submission analytics of a target
+>
+> | Argments | Type | Description
+> | `target` | db.models.Target | A single Target returned from the database
+> | `hours_ago` | int | The amount of hours since the current time to query the analytics for. (ex: `hours_ago=48` will query how many submissions were made in the last `48` hours. Defaults to lifetime when not set.)
+> | `kwargs` | kwargs | Information used to look up a Target in the database (ex: `codename`, `slug`, etc.)
+>
+>> Examples
+>> ```python3
+>> >>> h.targets.get_submissions_summary(codename='BLINKYBABOON')
+>> 35
+>> >>> 
+>> >>> h.targets.get_submissions_summary(hours_ago=48, codename='BLINKYBABOON')
+>> 5
+>> ```
+
+## targets.get_submissions(target, status="accepted", **kwargs)
+
+> Get the details of previously submitted vulnerabilities from the analytics of a target
+>
+> | Argments | Type | Description
+> | `target` | db.models.Target | A single Target returned from the database
+> | `status` | str | Query either `accepted`, `rejected` or `in_queue` vulnerabilities
+> | `kwargs` | kwargs | Information used to look up a Target in the database (ex: `codename`, `slug`, etc.)
+>
+>> Examples
+>> ```python3
+>> >>> h.targets.get_submissions(codename='BLINKYBABOON')
+>> [
+>>    {
+>>      "categories": ["Authorization/Permissions","SSRF"],
+>>      "exploitable_locations":[
+>>        {"type":"url","value":"https://example.com/index.html","created_at":1625646235,"status":"fixed"},
+>>        ...
+>>      ]
+>>    }, ...
+>> ]
+>>  
+>> >>> h.targets.get_submissions(status="in_queue", codename='BLINKYBABOON')
+>> [
+>>    {
+>>      "categories": ["Authorization/Permissions","SSRF"],
+>>      "exploitable_locations":[
+>>        {"type":"url","value":"https://example.com/login.html","created_at":1625646235,"status":"pending"},
+>>        ...
+>>      ]
+>>    }, ...
+>> ]
+>> ```

--- a/docs/src/usage/plugins/targets.md
+++ b/docs/src/usage/plugins/targets.md
@@ -269,6 +269,7 @@
 > Connect to a specified target
 >
 > | Argments | Type | Description
+> | --- | --- | ---
 > | `target` | db.models.Target | A single Target returned from the database
 > | `kwargs` | kwargs | Information used to look up a Target in the database (ex: `codename`, `slug`, etc.)
 >
@@ -305,6 +306,7 @@
 > Get the connection details of a target
 >
 > | Argments | Type | Description
+> | --- | --- | ---
 > | `target` | db.models.Target | A single Target returned from the database
 > | `kwargs` | kwargs | Information used to look up a Target in the database (ex: `codename`, `slug`, etc.)
 >
@@ -319,6 +321,7 @@
 > Get a summary of the submission analytics of a target
 >
 > | Argments | Type | Description
+> | --- | --- | ---
 > | `target` | db.models.Target | A single Target returned from the database
 > | `hours_ago` | int | The amount of hours since the current time to query the analytics for. (ex: `hours_ago=48` will query how many submissions were made in the last `48` hours. Defaults to lifetime when not set.)
 > | `kwargs` | kwargs | Information used to look up a Target in the database (ex: `codename`, `slug`, etc.)
@@ -337,6 +340,7 @@
 > Get the details of previously submitted vulnerabilities from the analytics of a target
 >
 > | Argments | Type | Description
+> | --- | --- | ---
 > | `target` | db.models.Target | A single Target returned from the database
 > | `status` | str | Query either `accepted`, `rejected` or `in_queue` vulnerabilities
 > | `kwargs` | kwargs | Information used to look up a Target in the database (ex: `codename`, `slug`, etc.)
@@ -353,7 +357,7 @@
 >>      ]
 >>    }, ...
 >> ]
->>  
+>> >>>
 >> >>> h.targets.get_submissions(status="in_queue", codename='BLINKYBABOON')
 >> [
 >>    {

--- a/src/synack/plugins/targets.py
+++ b/src/synack/plugins/targets.py
@@ -275,3 +275,48 @@ class Targets(Plugin):
         if len(targets) >= 15:
             ret.extend(self.set_registered())
         return ret
+
+    def get_connections(self, target=None, **kwargs):
+        """Get the connection details of a target."""
+        if target is None:
+            if len(kwargs) == 0:
+                kwargs = {'codename': self.get_connected().get('codename')}
+            target = self.db.find_targets(**kwargs)
+            if target:
+                target = target[0]
+        res = self.api.request('GET', "listing_analytics/connections", query={"listing_id":target.slug})
+        if res.status_code == 200:
+            return res.json()["value"]
+            # Example return value: {"lifetime_connections":200,"current_connections":0}
+
+    def get_submissions_summary(self, target=None, hours_ago=None, **kwargs):
+        """Get a summary of the submission analytics of a target."""
+        if target is None:
+            if len(kwargs) == 0:
+                kwargs = {'codename': self.get_connected().get('codename')}
+            target = self.db.find_targets(**kwargs)
+            if target:
+                target = target[0]
+        query = {"listing_id":target.slug}
+        if hours_ago:
+            query["period"] = f"{hours_ago}h"
+        res = self.api.request('GET', "listing_analytics/submissions", query=query)
+        if res.status_code == 200:
+            return res.json()["value"]
+
+    def get_submissions(self, target=None, status="accepted", **kwargs):
+        """Get the details of previously submitted vulnerabilities from the analytics of a target."""
+        if status not in ["accepted", "rejected", "in_queue"]:
+            return []
+        if target is None:
+            if len(kwargs) == 0:
+                kwargs = {'codename': self.get_connected().get('codename')}
+            target = self.db.find_targets(**kwargs)
+            if target:
+                target = target[0]
+        query = {"listing_id":target.slug, "status": status}
+        res = self.api.request('GET', "listing_analytics/categories", query=query)
+        if res.status_code == 200:
+            return res.json()["value"]
+            # Example return value: [{"categories":["Authorization/Permissions","SSRF"],"exploitable_locations":[{"type":"url","value":"https://example.com/index.html","created_at":1625646235,"status":"fixed"}]}]
+            


### PR DESCRIPTION
Allows you to query the analytics of a target using three new functions:
* `targets.get_connections()`
* `targets.get_submissions_summary()`
* `targets.get_submissions()`