### PR TITLE
Fix spurious debug logging in api.py

### DIFF
--- a/src/synack/plugins/api.py
+++ b/src/synack/plugins/api.py
@@ -150,7 +150,7 @@ class Api(Plugin):
         elif res.status_code == 403:
             reason_failed = 'Logged out'
         elif res.status_code == 412:
-            fail_reason = 'Mission already claimed'
+            reason_failed = 'Mission already claimed'
         elif res.status_code == 429:
             self._debug.log('Too many requests', f'({res.status_code} - {res.reason}) {res.url}')
             if attempts < 5:
@@ -165,6 +165,8 @@ class Api(Plugin):
                 attempts += 1
                 return self.request(method, path, attempts, **kwargs)
 
-        self._debug.log('Mission already claimed', f'({res.status_code} - {res.reason}) {res.url}')
+        # Log terminal failures (non-retryable errors)
+        if res.status_code in [400, 401, 403, 412]:
+            self._debug.log(reason_failed, f'({res.status_code} - {res.reason}) {res.url}')
 
         return res


### PR DESCRIPTION
## Summary

Fixed two bugs in the request error handling that caused misleading debug messages when debug mode was enabled.

## Issues Fixed

### 1. Typo in variable name (Line 153)
- **Before**: `fail_reason = 'Mission already claimed'`
- **After**: `reason_failed = 'Mission already claimed'`
- The variable `fail_reason` was never used, causing the message to never be logged correctly

### 2. Unconditional debug log (Line 168)
- **Before**: Debug log executed for **every** HTTP request regardless of status
- **After**: Only logs terminal failures (HTTP 400, 401, 403, 412)
- This caused "MISSION ALREADY CLAIMED" to appear for successful requests (200 OK), authentication flows, profile requests, etc.

## Impact

When `debug=True` was set, users would see confusing "MISSION ALREADY CLAIMED" messages for **every single HTTP request**, even ones completely unrelated to missions.

**Example - Before fix:**
```
2025-10-24 07:57:42 -- NETWORK REQUEST
	401 -- GET -- https://platform.synack.com/api/profiles/me
2025-10-24 07:57:42 -- MISSION ALREADY CLAIMED
	(401 - Unauthorized) https://platform.synack.com/api/profiles/me
```

**After fix:**
```
2025-10-24 08:06:50 -- NETWORK REQUEST
	200 -- GET -- https://platform.synack.com/api/profiles/me
[no spurious mission message]
```

Now "Mission already claimed" only appears for actual HTTP 412 responses.

## Root Cause

Bug was introduced in commit c406ca9d (March 2, 2025) during refactoring of error handling code.

## Testing

Tested with `debug=True` using `synack_check_target.py` - confirmed spurious messages are gone and only appropriate errors are logged.